### PR TITLE
fix: summaryでmerged/closedの返信メッセージも削除するように修正

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41975,22 +41975,33 @@ function buildSummaryBlocks(data) {
 async function deleteTrackedMessages(state, channel) {
   const messagesToDelete = [];
   for (const [number, entry] of Object.entries(state.pull_requests)) {
-    if (entry.channel === channel && entry.message_ts) {
-      messagesToDelete.push({ type: "PR", number, ts: entry.message_ts });
+    if (entry.channel === channel) {
+      if (entry.message_ts) {
+        messagesToDelete.push({ type: "PR", number, ts: entry.message_ts });
+      }
+      if (entry.reply_message_ts) {
+        messagesToDelete.push({ type: "PR", number, ts: entry.reply_message_ts, isReply: true });
+      }
     }
   }
   for (const [number, entry] of Object.entries(state.issues)) {
-    if (entry.channel === channel && entry.message_ts) {
-      messagesToDelete.push({ type: "Issue", number, ts: entry.message_ts });
+    if (entry.channel === channel) {
+      if (entry.message_ts) {
+        messagesToDelete.push({ type: "Issue", number, ts: entry.message_ts });
+      }
+      if (entry.reply_message_ts) {
+        messagesToDelete.push({ type: "Issue", number, ts: entry.reply_message_ts, isReply: true });
+      }
     }
   }
   core3.info(`Deleting ${messagesToDelete.length} messages...`);
   for (const msg of messagesToDelete) {
     const success = await deleteMessage(channel, msg.ts);
+    const msgType = msg.isReply ? `${msg.type} reply` : msg.type;
     if (success) {
-      core3.info(`Deleted ${msg.type} #${msg.number} message`);
+      core3.info(`Deleted ${msgType} #${msg.number} message`);
     } else {
-      core3.warning(`Failed to delete ${msg.type} #${msg.number} message`);
+      core3.warning(`Failed to delete ${msgType} #${msg.number} message`);
     }
   }
 }
@@ -42098,6 +42109,7 @@ async function handlePullRequest(inputs) {
     const messageTs = await postMessage(inputs.slackChannel, blocks, `PR #${pr.number} ${prEvent}`, threadTs);
     if (existingEntry) {
       existingEntry.event = prEvent;
+      existingEntry.reply_message_ts = messageTs;
     } else {
       addPREntry(state, prNumber, {
         channel: inputs.slackChannel,
@@ -42189,6 +42201,7 @@ async function handleIssue(inputs) {
     const messageTs = await postMessage(inputs.slackChannel, blocks, `Issue #${issue.number} closed`, threadTs);
     if (existingEntry) {
       existingEntry.event = "closed";
+      existingEntry.reply_message_ts = messageTs;
     } else {
       addIssueEntry(state, issueNumber, {
         channel: inputs.slackChannel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ async function handlePullRequest(inputs: ActionInputs): Promise<void> {
     // Update state
     if (existingEntry) {
       existingEntry.event = prEvent;
+      existingEntry.reply_message_ts = messageTs;
     } else {
       addPREntry(state, prNumber, {
         channel: inputs.slackChannel,
@@ -252,6 +253,7 @@ async function handleIssue(inputs: ActionInputs): Promise<void> {
     // Update state
     if (existingEntry) {
       existingEntry.event = 'closed';
+      existingEntry.reply_message_ts = messageTs;
     } else {
       addIssueEntry(state, issueNumber, {
         channel: inputs.slackChannel,

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -189,19 +189,29 @@ async function deleteTrackedMessages(
   state: NotificationState,
   channel: string
 ): Promise<void> {
-  const messagesToDelete: Array<{ type: string; number: string; ts: string }> = [];
+  const messagesToDelete: Array<{ type: string; number: string; ts: string; isReply?: boolean }> = [];
 
   // Collect PR messages
   for (const [number, entry] of Object.entries(state.pull_requests)) {
-    if (entry.channel === channel && entry.message_ts) {
-      messagesToDelete.push({ type: 'PR', number, ts: entry.message_ts });
+    if (entry.channel === channel) {
+      if (entry.message_ts) {
+        messagesToDelete.push({ type: 'PR', number, ts: entry.message_ts });
+      }
+      if (entry.reply_message_ts) {
+        messagesToDelete.push({ type: 'PR', number, ts: entry.reply_message_ts, isReply: true });
+      }
     }
   }
 
   // Collect Issue messages
   for (const [number, entry] of Object.entries(state.issues)) {
-    if (entry.channel === channel && entry.message_ts) {
-      messagesToDelete.push({ type: 'Issue', number, ts: entry.message_ts });
+    if (entry.channel === channel) {
+      if (entry.message_ts) {
+        messagesToDelete.push({ type: 'Issue', number, ts: entry.message_ts });
+      }
+      if (entry.reply_message_ts) {
+        messagesToDelete.push({ type: 'Issue', number, ts: entry.reply_message_ts, isReply: true });
+      }
     }
   }
 
@@ -209,10 +219,11 @@ async function deleteTrackedMessages(
 
   for (const msg of messagesToDelete) {
     const success = await deleteMessage(channel, msg.ts);
+    const msgType = msg.isReply ? `${msg.type} reply` : msg.type;
     if (success) {
-      core.info(`Deleted ${msg.type} #${msg.number} message`);
+      core.info(`Deleted ${msgType} #${msg.number} message`);
     } else {
-      core.warning(`Failed to delete ${msg.type} #${msg.number} message`);
+      core.warning(`Failed to delete ${msgType} #${msg.number} message`);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type EventType = 'pull_request' | 'issues' | 'workflow_run' | 'summary';
 export interface PullRequestEntry {
   channel: string;
   message_ts: string;
+  reply_message_ts?: string;
   created_at: string;
   event: 'opened' | 'closed' | 'merged';
   title: string;
@@ -17,6 +18,7 @@ export interface PullRequestEntry {
 export interface IssueEntry {
   channel: string;
   message_ts: string;
+  reply_message_ts?: string;
   created_at: string;
   event: 'opened' | 'closed';
   title: string;


### PR DESCRIPTION
## Summary
- PR/Issueがmerged/closedされた際の返信メッセージのtsを`reply_message_ts`として保存するように修正
- summaryの`deleteTrackedMessages`で`reply_message_ts`も削除対象に追加
- これにより、openedのメッセージだけでなくmerged/closedの返信メッセージもsummary時に削除されるようになった

## Test plan
- [ ] PRをopen → merged/closedし、summaryを実行して全メッセージが削除されることを確認
- [ ] Issueをopen → closedし、summaryを実行して全メッセージが削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)