### PR TITLE
feat: baseブランチフィルタリング機能を追加

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'When to notify for workflow_run: success,failure or failure'
     required: false
     default: 'success,failure'
+  base_branches:
+    description: 'Target base branches to notify (e.g., "main", "main,develop", or "all" for all branches)'
+    required: false
+    default: 'all'
 
 outputs:
   message_ts:
@@ -66,4 +70,5 @@ runs:
         INPUT_EXCLUDE_PROJECT_ISSUES: ${{ inputs.exclude_project_issues }}
         INPUT_WORKFLOW_NAMES: ${{ inputs.workflow_names }}
         INPUT_NOTIFY_ON: ${{ inputs.notify_on }}
+        INPUT_BASE_BRANCHES: ${{ inputs.base_branches }}
       run: node ${{ github.action_path }}/dist/index.js

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "gh-slack-notify",

--- a/dist/index.js
+++ b/dist/index.js
@@ -41738,6 +41738,12 @@ function shouldNotifyByLabels(labels, filterMode, filterLabels) {
     return !hasMatchingLabel;
   }
 }
+function shouldNotifyByBaseBranch(baseBranch, baseBranches) {
+  if (baseBranches.length === 0 || baseBranches.includes("all")) {
+    return true;
+  }
+  return baseBranches.some((branch) => branch.toLowerCase() === baseBranch.toLowerCase());
+}
 
 // src/state.ts
 var core2 = __toESM(require_core(), 1);
@@ -42067,6 +42073,7 @@ function getInputs() {
   const excludeProjectIssues = process.env.INPUT_EXCLUDE_PROJECT_ISSUES !== "false";
   const workflowNames = (process.env.INPUT_WORKFLOW_NAMES || "").split(",").map((w) => w.trim()).filter(Boolean);
   const notifyOn = (process.env.INPUT_NOTIFY_ON || "success,failure").split(",").map((n) => n.trim()).filter(Boolean);
+  const baseBranches = (process.env.INPUT_BASE_BRANCHES || "all").split(",").map((b) => b.trim()).filter(Boolean);
   return {
     eventType,
     slackToken,
@@ -42076,7 +42083,8 @@ function getInputs() {
     filterLabels,
     excludeProjectIssues,
     workflowNames,
-    notifyOn
+    notifyOn,
+    baseBranches
   };
 }
 async function handlePullRequest(inputs) {
@@ -42100,6 +42108,12 @@ async function handlePullRequest(inputs) {
   const labels = (pr.labels || []).map((l) => l.name);
   if (!shouldNotifyByLabels(labels, inputs.labelFilterMode, inputs.filterLabels)) {
     core4.info("PR filtered out by label filter");
+    core4.setOutput("notified", "false");
+    return;
+  }
+  const baseBranch = pr.base?.ref || "";
+  if (!shouldNotifyByBaseBranch(baseBranch, inputs.baseBranches)) {
+    core4.info(`PR filtered out by base branch filter (base: ${baseBranch})`);
     core4.setOutput("notified", "false");
     return;
   }

--- a/src/github.ts
+++ b/src/github.ts
@@ -88,3 +88,19 @@ export function shouldNotifyByLabels(
     return !hasMatchingLabel;
   }
 }
+
+// Check if base branch matches the filter
+export function shouldNotifyByBaseBranch(
+  baseBranch: string,
+  baseBranches: string[]
+): boolean {
+  if (baseBranches.length === 0 || baseBranches.includes('all')) {
+    // No filter configured or 'all' specified, always notify
+    return true;
+  }
+
+  // Check if base branch matches any of the configured branches
+  return baseBranches.some(
+    (branch) => branch.toLowerCase() === baseBranch.toLowerCase()
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { initSlackClient, postMessage, buildPRBlocks, buildIssueBlocks, buildWorkflowBlocks } from './slack.js';
-import { initGitHubClient, isIssueLinkedToProject, shouldNotifyByLabels } from './github.js';
+import { initGitHubClient, isIssueLinkedToProject, shouldNotifyByLabels, shouldNotifyByBaseBranch } from './github.js';
 import { readState, saveState, addPREntry, getPREntry, addIssueEntry, getIssueEntry } from './state.js';
 import { runSummary } from './summary.js';
 import { COLORS, type ActionInputs, type EventType } from './types.js';
@@ -26,6 +26,10 @@ function getInputs(): ActionInputs {
     .split(',')
     .map((n) => n.trim())
     .filter(Boolean);
+  const baseBranches = (process.env.INPUT_BASE_BRANCHES || 'all')
+    .split(',')
+    .map((b) => b.trim())
+    .filter(Boolean);
 
   return {
     eventType,
@@ -37,6 +41,7 @@ function getInputs(): ActionInputs {
     excludeProjectIssues,
     workflowNames,
     notifyOn,
+    baseBranches,
   };
 }
 
@@ -68,6 +73,14 @@ async function handlePullRequest(inputs: ActionInputs): Promise<void> {
   const labels = (pr.labels || []).map((l: { name: string }) => l.name);
   if (!shouldNotifyByLabels(labels, inputs.labelFilterMode, inputs.filterLabels)) {
     core.info('PR filtered out by label filter');
+    core.setOutput('notified', 'false');
+    return;
+  }
+
+  // Check base branch filter
+  const baseBranch = pr.base?.ref || '';
+  if (!shouldNotifyByBaseBranch(baseBranch, inputs.baseBranches)) {
+    core.info(`PR filtered out by base branch filter (base: ${baseBranch})`);
     core.setOutput('notified', 'false');
     return;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface ActionInputs {
   excludeProjectIssues: boolean;
   workflowNames: string[];
   notifyOn: string[];
+  baseBranches: string[];
 }
 
 // Slack message colors


### PR DESCRIPTION
- action.ymlにbase_branchesパラメータを追加（デフォルト: all）
- 複数のbaseブランチをカンマ区切りで指定可能（例: main,develop）
- "all"指定で全ブランチを対象
- shouldNotifyByBaseBranch関数を追加してフィルタリングを実装
- PRイベント処理時にbaseブランチをチェック