### PR TITLE
fix: split daily summary into per-event sections

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -112927,14 +112927,15 @@ function collectSummaryData(state) {
   }
   return data;
 }
-function buildSummaryBlocks(data) {
+function buildSummaryBlocks(data, repository) {
   const today = new Date().toISOString().split("T")[0];
+  const summaryTitle = repository ? `:scroll: Daily Summary (${repository}) - ${today}` : `:scroll: Daily Summary - ${today}`;
   const blocks = [
     {
       type: "header",
       text: {
         type: "plain_text",
-        text: `:scroll: Daily Summary - ${today}`,
+        text: summaryTitle,
         emoji: true
       }
     }
@@ -112999,12 +113000,12 @@ async function deleteTrackedMessages(state, channel) {
     }
   }
 }
-async function runSummary(channel) {
+async function runSummary(channel, repository) {
   core3.info("Running daily summary...");
   const state = await readState();
   const data = collectSummaryData(state);
-  const blocks = buildSummaryBlocks(data);
-  const text = "Daily Summary";
+  const blocks = buildSummaryBlocks(data, repository);
+  const text = repository ? `Daily Summary (${repository})` : "Daily Summary";
   await postMessage(channel, blocks, text);
   core3.info("Summary posted to Slack");
   await deleteTrackedMessages(state, channel);
@@ -113314,7 +113315,7 @@ async function main() {
         await handleWorkflowRun(inputs);
         break;
       case "summary":
-        await runSummary(inputs.slackChannel);
+        await runSummary(inputs.slackChannel, `${github2.context.repo.owner}/${github2.context.repo.repo}`);
         break;
       default:
         throw new Error(`Unknown event_type: ${inputs.eventType}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,10 @@ async function main(): Promise<void> {
         await handleWorkflowRun(inputs);
         break;
       case 'summary':
-        await runSummary(inputs.slackChannel);
+        await runSummary(
+          inputs.slackChannel,
+          `${github.context.repo.owner}/${github.context.repo.repo}`
+        );
         break;
       default:
         throw new Error(`Unknown event_type: ${inputs.eventType}`);

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -111,15 +111,18 @@ function collectSummaryData(state: NotificationState): SummaryData {
 }
 
 // Build summary message blocks
-function buildSummaryBlocks(data: SummaryData): KnownBlock[] {
+function buildSummaryBlocks(data: SummaryData, repository: string): KnownBlock[] {
   const today = new Date().toISOString().split('T')[0];
+  const summaryTitle = repository
+    ? `:scroll: Daily Summary (${repository}) - ${today}`
+    : `:scroll: Daily Summary - ${today}`;
 
   const blocks: KnownBlock[] = [
     {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `:scroll: Daily Summary - ${today}`,
+        text: summaryTitle,
         emoji: true,
       },
     },
@@ -222,7 +225,7 @@ async function deleteTrackedMessages(
 }
 
 // Run the daily summary
-export async function runSummary(channel: string): Promise<void> {
+export async function runSummary(channel: string, repository: string): Promise<void> {
   core.info('Running daily summary...');
 
   // 1. Read state
@@ -232,8 +235,8 @@ export async function runSummary(channel: string): Promise<void> {
   const data = collectSummaryData(state);
 
   // 3. Build and send summary message
-  const blocks = buildSummaryBlocks(data);
-  const text = 'Daily Summary';
+  const blocks = buildSummaryBlocks(data, repository);
+  const text = repository ? `Daily Summary (${repository})` : 'Daily Summary';
 
   await postMessage(channel, blocks, text);
   core.info('Summary posted to Slack');


### PR DESCRIPTION
## 背景
`event_type: summary` 実行時、Slack API から `invalid_blocks` が返って通知に失敗していた。

- エラー: `must be less than 3001 characters [json-pointer:/blocks/2/text/text]`
- 原因: Daily summary で PR/Issue の一覧を 1 つの section block に連結しており、本文が 3000 文字制限を超えるケースがあった。

## 変更内容
- Summary の表示をイベントごとに分割
  - Pull Requests / Opened
  - Pull Requests / Closed
  - Pull Requests / Merged
  - Issues / Opened
  - Issues / Closed
- `pushSummarySection` を追加し、各 section の本文を 3000 文字未満で自動分割
  - 長文時は ` (cont.)` を付けて継続 section を作成
- Summary ヘッダーと fallback text に repository 名（`owner/repo`）を追加
  - 例: `:scroll: Daily Summary (ut61z/gh-slack-notify) - YYYY-MM-DD`
- 既存の `_No activity today_ 🎉` 表示はそのまま維持
- `dist/index.js` を再ビルドして更新

## 期待される効果
- Daily summary 実行時の `invalid_blocks` を回避
- 件数が多い日でも Slack 投稿が失敗しない
- Summary タイトルだけで対象 repository を判別できる

## 変更ファイル
- `src/index.ts`
- `src/summary.ts`
- `dist/index.js`
