### PR TITLE
feat: ready_for_reviewアクションをopenedとして通知する

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -113059,7 +113059,7 @@ async function handlePullRequest(inputs) {
   const prNumber = pr.number.toString();
   const isMerged = pr.merged === true;
   let prEvent;
-  if (action === "opened") {
+  if (action === "opened" || action === "ready_for_review") {
     prEvent = "opened";
   } else if (action === "closed") {
     prEvent = isMerged ? "merged" : "closed";

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ async function handlePullRequest(inputs: ActionInputs): Promise<void> {
 
   // Determine the actual event type
   let prEvent: 'opened' | 'closed' | 'merged';
-  if (action === 'opened') {
+  if (action === 'opened' || action === 'ready_for_review') {
     prEvent = 'opened';
   } else if (action === 'closed') {
     prEvent = isMerged ? 'merged' : 'closed';


### PR DESCRIPTION
## Summary
- Draft PRが「Ready for Review」になった際の `ready_for_review` アクションを `opened` イベントとして扱い、Slack通知が飛ぶようにした

## Test plan
- [ ] Draft PRを作成し、Ready for Reviewに変更して通知が飛ぶことを確認
- [ ] 通常のPR open/close/mergeの通知が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)