### PR TITLE
chore: update action runtime to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,5 +59,5 @@ outputs:
     description: 'Whether a notification was sent (true/false)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
This addresses the upcoming deprecation for Node.js v20: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/